### PR TITLE
add re-usable navigation bar

### DIFF
--- a/client/src/components/Navbar/DisplayDesktop.tsx
+++ b/client/src/components/Navbar/DisplayDesktop.tsx
@@ -1,0 +1,30 @@
+import { Toolbar, Typography, Grid } from '@material-ui/core';
+import PetsIcon from '@material-ui/icons/Pets';
+import useStyles from './useStyles';
+import GetMenuButtons from './GetMenuButtons';
+
+interface Props {
+  mySitter: string;
+  becomeSitter: string;
+  messages: string;
+}
+const DisplayDesktop = ({}: Props): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <Toolbar>
+      <Grid container>
+        <Grid item container sm={2} alignContent="center">
+          <PetsIcon fontSize="large" className={classes.icon} />
+          <Typography variant="h5" align="center" noWrap className={classes.logo}>
+            LovingSitter.
+          </Typography>
+        </Grid>
+        <Grid sm={10} item container className={classes.toolbarGrid}>
+          <GetMenuButtons mySitter="My Sitters" becomeSitter="BECOME A SITTER" messages="Messages" />
+        </Grid>
+      </Grid>
+    </Toolbar>
+  );
+};
+export default DisplayDesktop;

--- a/client/src/components/Navbar/DisplayDesktop.tsx
+++ b/client/src/components/Navbar/DisplayDesktop.tsx
@@ -4,11 +4,21 @@ import useStyles from './useStyles';
 import GetMenuButtons from './GetMenuButtons';
 
 interface Props {
-  mySitter: string;
-  becomeSitter: string;
-  messages: string;
+  MY_SITTER: string;
+  BECOME_SITTER: string;
+  MESSAGE: string;
+  Mysitter: string;
+  Becomesitter: string;
+  Messages: string;
 }
-const DisplayDesktop = ({}: Props): JSX.Element => {
+const DisplayDesktop = ({
+  MY_SITTER,
+  BECOME_SITTER,
+  MESSAGE,
+  Mysitter,
+  Becomesitter,
+  Messages,
+}: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
@@ -21,7 +31,14 @@ const DisplayDesktop = ({}: Props): JSX.Element => {
           </Typography>
         </Grid>
         <Grid sm={10} item container className={classes.toolbarGrid}>
-          <GetMenuButtons mySitter="My Sitters" becomeSitter="BECOME A SITTER" messages="Messages" />
+          <GetMenuButtons
+            Mysitter={Mysitter}
+            Becomesitter={Becomesitter}
+            Messages={Messages}
+            BECOME_SITTER={BECOME_SITTER}
+            MY_SITTER={MY_SITTER}
+            MESSAGE={MESSAGE}
+          />
         </Grid>
       </Grid>
     </Toolbar>

--- a/client/src/components/Navbar/DisplayMobile.tsx
+++ b/client/src/components/Navbar/DisplayMobile.tsx
@@ -8,9 +8,11 @@ import GetDrawerChoices from './GetDrawerChoices';
 interface Props {
   LOGOUT: string;
   PROFILE: string;
+  Logout: string;
+  Profile: string;
 }
 
-const DisplayMobile = ({}: Props): JSX.Element => {
+const DisplayMobile = ({ LOGOUT, PROFILE, Logout, Profile }: Props): JSX.Element => {
   const classes = useStyles();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const handleDrawerOpen = () => setDrawerOpen(true);
@@ -47,7 +49,7 @@ const DisplayMobile = ({}: Props): JSX.Element => {
           onClose: handleDrawerClose,
         }}
       >
-        <GetDrawerChoices LOGOUT="logout" PROFILE="profile" />
+        <GetDrawerChoices LOGOUT={LOGOUT} PROFILE={PROFILE} Logout={Logout} Profile={Profile} />
       </Drawer>
     </Toolbar>
   );

--- a/client/src/components/Navbar/DisplayMobile.tsx
+++ b/client/src/components/Navbar/DisplayMobile.tsx
@@ -1,0 +1,55 @@
+import { Toolbar, Typography, Grid, IconButton, Drawer } from '@material-ui/core';
+import MenuIcon from '@material-ui/icons/Menu';
+import PetsIcon from '@material-ui/icons/Pets';
+import { useState } from 'react';
+import useStyles from './useStyles';
+import GetDrawerChoices from './GetDrawerChoices';
+
+interface Props {
+  LOGOUT: string;
+  PROFILE: string;
+}
+
+const DisplayMobile = ({}: Props): JSX.Element => {
+  const classes = useStyles();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const handleDrawerOpen = () => setDrawerOpen(true);
+  const handleDrawerClose = () => setDrawerOpen(false);
+
+  return (
+    <Toolbar>
+      <Grid item container alignContent="center">
+        <PetsIcon fontSize="large" className={classes.icon} />
+        <Typography variant="h5" align="center" noWrap className={classes.logo}>
+          LovingSitter.
+        </Typography>
+      </Grid>
+
+      <IconButton
+        {...{
+          edge: 'start',
+          color: 'secondary',
+          'aria-label': 'menu',
+          'aria-haspopup': 'true',
+          onClick: handleDrawerOpen,
+        }}
+        classes={{
+          root: classes.iconRoot,
+        }}
+      >
+        <MenuIcon />
+      </IconButton>
+
+      <Drawer
+        {...{
+          anchor: 'right',
+          open: drawerOpen,
+          onClose: handleDrawerClose,
+        }}
+      >
+        <GetDrawerChoices LOGOUT="logout" PROFILE="profile" />
+      </Drawer>
+    </Toolbar>
+  );
+};
+export default DisplayMobile;

--- a/client/src/components/Navbar/GetDrawerChoices.tsx
+++ b/client/src/components/Navbar/GetDrawerChoices.tsx
@@ -5,17 +5,19 @@ import useStyles from './useStyles';
 interface Props {
   LOGOUT: string;
   PROFILE: string;
+  Logout: string;
+  Profile: string;
 }
 
-const GetDrawerChoices = ({ LOGOUT, PROFILE }: Props): JSX.Element => {
+const GetDrawerChoices = ({ LOGOUT, PROFILE, Logout, Profile }: Props): JSX.Element => {
   const classes = useStyles();
   return (
     <React.Fragment>
       <Link to={LOGOUT} className={classes.menuDownButton}>
-        Log out
+        {Logout}
       </Link>
       <Link to={PROFILE} className={classes.menuDownButton}>
-        Go to profile
+        {Profile}
       </Link>
     </React.Fragment>
   );

--- a/client/src/components/Navbar/GetDrawerChoices.tsx
+++ b/client/src/components/Navbar/GetDrawerChoices.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom';
+import React from 'react';
+import useStyles from './useStyles';
+
+interface Props {
+  LOGOUT: string;
+  PROFILE: string;
+}
+
+const GetDrawerChoices = ({ LOGOUT, PROFILE }: Props): JSX.Element => {
+  const classes = useStyles();
+  return (
+    <React.Fragment>
+      <Link to={LOGOUT} className={classes.menuDownButton}>
+        Log out
+      </Link>
+      <Link to={PROFILE} className={classes.menuDownButton}>
+        Go to profile
+      </Link>
+    </React.Fragment>
+  );
+};
+export default GetDrawerChoices;

--- a/client/src/components/Navbar/GetMenuButtons.tsx
+++ b/client/src/components/Navbar/GetMenuButtons.tsx
@@ -6,26 +6,36 @@ import useStyles from './useStyles';
 import { useAuth } from '../../context/useAuthContext';
 
 interface Props {
-  mySitter: string;
-  becomeSitter: string;
-  messages: string;
+  MY_SITTER: string;
+  BECOME_SITTER: string;
+  MESSAGE: string;
+  Mysitter: string;
+  Becomesitter: string;
+  Messages: string;
 }
 
-const GetMenuButtons = ({ mySitter, becomeSitter, messages }: Props): JSX.Element => {
+const GetMenuButtons = ({
+  Mysitter,
+  Becomesitter,
+  Messages,
+  MY_SITTER,
+  BECOME_SITTER,
+  MESSAGE,
+}: Props): JSX.Element => {
   const classes = useStyles();
   const { loggedInUser } = useAuth();
 
   return (
     <React.Fragment>
-      <Link to={becomeSitter} className={classes.becomeSitter}>
-        {becomeSitter}
+      <Link to={BECOME_SITTER} className={classes.becomeSitter}>
+        {Becomesitter}
       </Link>
-      <Link to={mySitter} className={classes.menuDownButton}>
-        My Sitters
+      <Link to={MY_SITTER} className={classes.menuDownButton}>
+        {Mysitter}
       </Link>
       <Box className={classes.menuDownButton}>
-        <Link to={messages} className={classes.messageLink}>
-          Messages
+        <Link to={MESSAGE} className={classes.messageLink}>
+          {Messages}
         </Link>
         <Badge
           badgeContent=" "
@@ -38,7 +48,7 @@ const GetMenuButtons = ({ mySitter, becomeSitter, messages }: Props): JSX.Elemen
       </Box>
 
       <Box className={classes.dashboardAvatar}>
-        <Avatar alt="Profile Image" src={`https://robohash.org/${loggedInUser}.png`} />;
+        <Avatar alt="Profile Image" src={`https://robohash.org/${loggedInUser!.email}.png`} />;
       </Box>
     </React.Fragment>
   );

--- a/client/src/components/Navbar/GetMenuButtons.tsx
+++ b/client/src/components/Navbar/GetMenuButtons.tsx
@@ -1,0 +1,46 @@
+import { Badge, Box, Avatar } from '@material-ui/core';
+
+import { Link } from 'react-router-dom';
+import React from 'react';
+import useStyles from './useStyles';
+import { useAuth } from '../../context/useAuthContext';
+
+interface Props {
+  mySitter: string;
+  becomeSitter: string;
+  messages: string;
+}
+
+const GetMenuButtons = ({ mySitter, becomeSitter, messages }: Props): JSX.Element => {
+  const classes = useStyles();
+  const { loggedInUser } = useAuth();
+
+  return (
+    <React.Fragment>
+      <Link to={becomeSitter} className={classes.becomeSitter}>
+        {becomeSitter}
+      </Link>
+      <Link to={mySitter} className={classes.menuDownButton}>
+        My Sitters
+      </Link>
+      <Box className={classes.menuDownButton}>
+        <Link to={messages} className={classes.messageLink}>
+          Messages
+        </Link>
+        <Badge
+          badgeContent=" "
+          color="primary"
+          variant="dot"
+          classes={{
+            root: classes.badgeRoot,
+          }}
+        ></Badge>
+      </Box>
+
+      <Box className={classes.dashboardAvatar}>
+        <Avatar alt="Profile Image" src={`https://robohash.org/${loggedInUser}.png`} />;
+      </Box>
+    </React.Fragment>
+  );
+};
+export default GetMenuButtons;

--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -7,12 +7,28 @@ import DisplayMobile from './DisplayMobile';
 interface Props {
   LOGOUT: string;
   PROFILE: string;
-  mySitter: string;
-  becomeSitter: string;
-  messages: string;
+  MY_SITTER: string;
+  BECOME_SITTER: string;
+  MESSAGE: string;
+  Logout: string;
+  Profile: string;
+  Mysitter: string;
+  Becomesitter: string;
+  Messages: string;
 }
 
-const Navbar = ({}: Props): JSX.Element => {
+const Navbar = ({
+  LOGOUT,
+  PROFILE,
+  MY_SITTER,
+  BECOME_SITTER,
+  MESSAGE,
+  Logout,
+  Profile,
+  Mysitter,
+  Becomesitter,
+  Messages,
+}: Props): JSX.Element => {
   const classes = useStyles();
 
   const [mobileView, setMobileView] = useState(false);
@@ -35,9 +51,16 @@ const Navbar = ({}: Props): JSX.Element => {
     <Box>
       <AppBar elevation={3} position="fixed" className={classes.navbar}>
         {mobileView ? (
-          <DisplayMobile LOGOUT="logout" PROFILE="profile" />
+          <DisplayMobile LOGOUT={LOGOUT} PROFILE={PROFILE} Logout={Logout} Profile={Profile} />
         ) : (
-          <DisplayDesktop mySitter="My Sitters" becomeSitter="BECOME A SITTER" messages="Messages" />
+          <DisplayDesktop
+            Mysitter={Mysitter}
+            Becomesitter={Becomesitter}
+            Messages={Messages}
+            BECOME_SITTER={BECOME_SITTER}
+            MY_SITTER={MY_SITTER}
+            MESSAGE={MESSAGE}
+          />
         )}
       </AppBar>
     </Box>

--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -1,0 +1,47 @@
+import { AppBar, Box } from '@material-ui/core';
+import { useState, useEffect } from 'react';
+import useStyles from './useStyles';
+import DisplayDesktop from './DisplayDesktop';
+import DisplayMobile from './DisplayMobile';
+
+interface Props {
+  LOGOUT: string;
+  PROFILE: string;
+  mySitter: string;
+  becomeSitter: string;
+  messages: string;
+}
+
+const Navbar = ({}: Props): JSX.Element => {
+  const classes = useStyles();
+
+  const [mobileView, setMobileView] = useState(false);
+
+  useEffect(() => {
+    const setResponsiveness = () => {
+      return window.innerWidth < 1200 ? setMobileView(true) : setMobileView(false);
+    };
+
+    setResponsiveness();
+
+    window.addEventListener('resize', () => setResponsiveness());
+
+    return () => {
+      window.removeEventListener('resize', () => setResponsiveness());
+    };
+  }, []);
+
+  return (
+    <Box>
+      <AppBar elevation={3} position="fixed" className={classes.navbar}>
+        {mobileView ? (
+          <DisplayMobile LOGOUT="logout" PROFILE="profile" />
+        ) : (
+          <DisplayDesktop mySitter="My Sitters" becomeSitter="BECOME A SITTER" messages="Messages" />
+        )}
+      </AppBar>
+    </Box>
+  );
+};
+
+export default Navbar;

--- a/client/src/components/Navbar/useStyles.ts
+++ b/client/src/components/Navbar/useStyles.ts
@@ -1,0 +1,68 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  navbar: {
+    backgroundColor: 'white',
+  },
+
+  toolbarGrid: {
+    justifyContent: 'flex-end',
+    paddingRight: '3rem',
+  },
+  dashboardAvatar: {
+    marginTop: '0.5rem',
+    marginLeft: '2rem',
+  },
+  badgeRoot: { color: 'green' },
+  iconRoot: { color: 'red' },
+  menuDownButton: {
+    padding: theme.spacing(3),
+    display: 'flex',
+    color: '#000',
+    textDecoration: 'none',
+    fontWeight: 700,
+    marginLeft: '0',
+    '&:hover': {
+      color: 'grey',
+      textDecoration: 'none',
+    },
+  },
+  messageLink: {
+    color: '#000',
+    display: 'flex',
+    padding: '0',
+    paddingRight: '0.5rem',
+
+    textDecoration: 'none',
+    '&:hover': {
+      color: 'grey',
+      textDecoration: 'none',
+    },
+  },
+
+  drawerContainer: {
+    padding: '0rem 2rem',
+  },
+  logo: {
+    fontWeight: 700,
+    marginLeft: '0.7rem',
+    color: '#000',
+  },
+  becomeSitter: {
+    padding: theme.spacing(3),
+    display: 'flex',
+    color: '#000',
+    fontWeight: 700,
+    textDecoration: 'underline',
+    '&:hover': {
+      color: 'grey',
+      textDecoration: 'none',
+    },
+  },
+  icon: {
+    color: 'red',
+    marginLeft: '2rem',
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import { useSocket } from '../../context/useSocketContext';
 import { useHistory } from 'react-router-dom';
 import ChatSideBanner from '../../components/ChatSideBanner/ChatSideBanner';
 import { useEffect } from 'react';
+import Navbar from '../../components/Navbar/Navbar';
 
 export default function Dashboard(): JSX.Element {
   const classes = useStyles();
@@ -29,6 +30,13 @@ export default function Dashboard(): JSX.Element {
 
   return (
     <Grid container component="main" className={`${classes.root} ${classes.dashboard}`}>
+      <Navbar
+        LOGOUT="logout"
+        PROFILE="profile"
+        mySitter="My Sitters"
+        becomeSitter="BECOME A SITTER"
+        messages="Messages"
+      />
       <CssBaseline />
       <Grid item className={classes.drawerWrapper}>
         <ChatSideBanner loggedInUser={loggedInUser} />

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -31,11 +31,16 @@ export default function Dashboard(): JSX.Element {
   return (
     <Grid container component="main" className={`${classes.root} ${classes.dashboard}`}>
       <Navbar
-        LOGOUT="logout"
-        PROFILE="profile"
-        mySitter="My Sitters"
-        becomeSitter="BECOME A SITTER"
-        messages="Messages"
+        LOGOUT="/logout"
+        PROFILE="/profile"
+        MY_SITTER="/mySitter"
+        BECOME_SITTER="/becomeSitter"
+        MESSAGE="/message"
+        Logout="Log out"
+        Profile="Profile"
+        Mysitter="My Sitters"
+        Becomesitter="BECOME A SITTER"
+        Messages="Messages"
       />
       <CssBaseline />
       <Grid item className={classes.drawerWrapper}>


### PR DESCRIPTION
### What this PR does (required):
- Adds a navigation bar to the project
- This navigation bar can be used for another project

### Screenshots / Videos (required):

![ticket15first](https://user-images.githubusercontent.com/54731878/129062298-f4f4e4c6-4558-40d9-aee4-1958b289fee9.png)

![ticket15secon](https://user-images.githubusercontent.com/54731878/129062352-feb43353-6c6d-4979-828a-b9e490304aa5.png)


![ticket15third](https://user-images.githubusercontent.com/54731878/129062385-3218f01b-343a-44d0-b954-b7880449774a.png)


### Any information needed to test this feature (required):
- Post what steps to take to be able to test this feature (eg. "sign up as a new user and upload a profile picture from the navbar")

### Any issues with the current functionality (optional):
- Clicking on the options will take you to logout
- Routing functionality is not integrated

